### PR TITLE
feat: improve remote cache use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ build/Release
 # Dependency directories
 node_modules/
 jspm_packages/
+package-lock.json
 
 # TypeScript v1 declaration files
 typings/

--- a/.taprc
+++ b/.taprc
@@ -1,1 +1,0 @@
-check-coverage: false

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -2,7 +2,7 @@
 
 const fastify = require('fastify')
 const mercurius = require('mercurius')
-const cache = require('.')
+const cache = require('mercurius-cache')
 
 const app = fastify({ logger: true })
 

--- a/examples/redis.js
+++ b/examples/redis.js
@@ -48,7 +48,7 @@ app.register(cache, {
   },
   get: async function (key) {
     try {
-      return await app.redis.get(key)
+      return JSON.parse(await app.redis.get(key))
     } catch (err) {
       app.log.error({ msg: 'error on get from redis', err, key })
     }

--- a/examples/redis.js
+++ b/examples/redis.js
@@ -56,7 +56,7 @@ app.register(cache, {
   },
   set: async function (key, value) {
     try {
-      await app.redis.set(key, value, 'EX', ttl)
+      await app.redis.set(key, JSON.stringify(value), 'EX', ttl)
     } catch (err) {
       app.log.error({ msg: 'error on set into redis', err, key })
     }

--- a/examples/redis.js
+++ b/examples/redis.js
@@ -1,0 +1,76 @@
+'use strict'
+
+const fastify = require('fastify')
+const mercurius = require('mercurius')
+const redis = require('fastify-redis')
+const cache = require('mercurius-cache')
+
+const app = fastify({ logger: true })
+
+const schema = `
+  type Query {
+    add(x: Int, y: Int): Int
+    hello: String
+  }
+`
+
+const resolvers = {
+  Query: {
+    async add (_, { x, y }, { reply }) {
+      reply.log.info('add called')
+      for (let i = 0; i < 10000000; i++) {
+        // empty for a reason
+      }
+      return x + y
+    },
+    async hello () {
+      return 'world'
+    }
+  }
+}
+
+app.register(mercurius, {
+  schema,
+  resolvers
+})
+
+app.register(redis)
+
+const ttl = 60
+
+app.register(cache, {
+  // note: no ttl option
+  policy: {
+    Query: {
+      add: true,
+      hello: true
+    }
+  },
+  get: async function (key) {
+    try {
+      return await app.redis.get(key)
+    } catch (err) {
+      app.log.error({ msg: 'error on get from redis', err, key })
+    }
+    return null
+  },
+  set: async function (key, value) {
+    try {
+      await app.redis.set(key, value, 'EX', ttl)
+    } catch (err) {
+      app.log.error({ msg: 'error on set into redis', err, key })
+    }
+  },
+  onHit: function (type, fieldName) {
+    app.log.info({ msg: 'hit from cache', type, fieldName })
+  },
+  onMiss: function (type, fieldName) {
+    app.log.info({ msg: 'miss from cache', type, fieldName })
+  }
+
+})
+
+app.listen(3000)
+
+// Use the following to test
+// curl -X POST -H 'content-type: application/json' -d '{ "query": "{ add(x: 2, y: 2) }" }' localhost:3000/graphql

--- a/index.js
+++ b/index.js
@@ -98,8 +98,9 @@ function makeCachedResolver (prefix, fieldName, cache, originalFieldResolver, sk
     if (remoteCache) {
       const val = await remoteCache.get(name + '~' + key)
       if (val) {
+        const parsed = JSON.parse(val)
         onHit()
-        return val
+        return parsed
       }
     }
     onMiss()

--- a/index.js
+++ b/index.js
@@ -98,15 +98,14 @@ function makeCachedResolver (prefix, fieldName, cache, originalFieldResolver, sk
     if (remoteCache) {
       const val = await remoteCache.get(name + '~' + key)
       if (val) {
-        const parsed = JSON.parse(val)
         onHit()
-        return parsed
+        return val
       }
     }
     onMiss()
     const res = await originalFieldResolver(self, arg, ctx, info)
     if (remoteCache) {
-      await remoteCache.set(name + '~' + key, JSON.stringify(res))
+      await remoteCache.set(name + '~' + key, res)
     }
     return res
   })

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -574,3 +574,14 @@ test('external cache', async ({ equal, same, pass, plan, teardown }) => {
     })
   }
 })
+
+test('using both policy and all options', async (t) => {
+  const app = fastify()
+  app.register(mercurius)
+  app.register(cache, {
+    all: true,
+    policy: { Query: { add: true } }
+  })
+
+  await t.rejects(app.ready())
+})


### PR DESCRIPTION
in this PR I'd like to add to the repository

- consistent get/set to remote cache: since `set` stringify the value, on `get` it should be parsed to return the original value
- example using `redis` for remote cache
- 100% test coverage :)
