### PR TITLE
chore: async-cache-dedupe strict version dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "wait-on": "^6.0.0"
   },
   "dependencies": {
-    "async-cache-dedupe": "^0.5.0",
+    "async-cache-dedupe": "0.5.0",
     "fastify-plugin": "^3.0.0"
   },
   "precommit": "test"


### PR DESCRIPTION
we could have minor breaking changes, since we are in 0 version