### PR TITLE
Make default onError log the error with a debug level

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -64,6 +64,8 @@ function validateOpts (app, opts = {}) {
     if (typeof onError !== 'function') {
       throw new Error('onError must be a function')
     }
+  } else if (app.log && app.log.debug && typeof app.log.debug === 'function') {
+    onError = app.log.debug
   } else {
     onError = noop
   }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -65,9 +65,7 @@ function validateOpts (app, opts = {}) {
       throw new Error('onError must be a function')
     }
   } else if (app.log && app.log.debug && typeof app.log.debug === 'function') {
-    onError = (prefix, fieldName, err) => {
-      app.log.debug({ err, msg: 'Mercurius cache error', prefix, fieldName })
-    }
+    onError = defaultDebug(app)
   } else {
     onError = noop
   }
@@ -164,5 +162,11 @@ function validateStorage (app, storage, maxTTL) {
 }
 
 function noop () { }
+
+function defaultDebug (app) {
+  return function (prefix, fieldName, err) {
+    app.log.debug({ err, msg: 'Mercurius cache error', prefix, fieldName })
+  }
+}
 
 module.exports.validateOpts = validateOpts

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -65,7 +65,9 @@ function validateOpts (app, opts = {}) {
       throw new Error('onError must be a function')
     }
   } else if (app.log && app.log.debug && typeof app.log.debug === 'function') {
-    onError = app.log.debug
+    onError = (prefix, fieldName, err) => {
+      app.log.debug({ err, msg: 'Mercurius cache error', prefix, fieldName })
+    }
   } else {
     onError = noop
   }

--- a/test/lib-validation.test.js
+++ b/test/lib-validation.test.js
@@ -21,7 +21,10 @@ test('should get default options', async (t) => {
 })
 
 test('should get default options with log object', async (t) => {
-  const app = { log: { debug: () => 'debug error' } }
+  t.plan(13)
+  const app = {
+    log: { debug }
+  }
   const options = validateOpts(app)
   t.same(options.storage, { type: 'memory' })
   t.equal(options.ttl, 0)
@@ -35,7 +38,17 @@ test('should get default options with log object', async (t) => {
   t.equal(typeof options.onMiss, 'function')
   t.equal(typeof options.onSkip, 'function')
   t.equal(typeof options.onError, 'function')
-  t.equal(options.onError(), 'debug error')
+  // Trigger options.onError to be tested on callback at top
+  const except = {
+    prefix: 'Query',
+    fieldName: 'add',
+    err: 'Error',
+    msg: 'Mercurius cache error'
+  }
+  options.onError(except.prefix, except.fieldName, except.err)
+  function debug (params) {
+    t.same(params, except)
+  }
 })
 
 test('should get default storage.options', async (t) => {

--- a/test/lib-validation.test.js
+++ b/test/lib-validation.test.js
@@ -20,6 +20,24 @@ test('should get default options', async (t) => {
   t.equal(typeof options.onError, 'function')
 })
 
+test('should get default options with log object', async (t) => {
+  const app = { log: { debug: () => 'debug error' } }
+  const options = validateOpts(app)
+  t.same(options.storage, { type: 'memory' })
+  t.equal(options.ttl, 0)
+  t.equal(options.all, undefined)
+  t.equal(options.policy, undefined)
+  t.equal(options.skip, undefined)
+  t.equal(options.logInterval, undefined)
+  t.equal(options.logReport, undefined)
+  t.equal(typeof options.onDedupe, 'function')
+  t.equal(typeof options.onHit, 'function')
+  t.equal(typeof options.onMiss, 'function')
+  t.equal(typeof options.onSkip, 'function')
+  t.equal(typeof options.onError, 'function')
+  t.equal(options.onError(), 'debug error')
+})
+
 test('should get default storage.options', async (t) => {
   const options = {
     ttl: 1,
@@ -96,6 +114,11 @@ const cases = [
     title: 'should get error using all as string',
     options: { all: 'true' },
     expect: /all must be a boolean/
+  },
+  {
+    title: 'should get error using all and policy',
+    options: { all: true, policy: {} },
+    expect: /policy and all options are exclusive/
   },
   {
     title: 'should get error using ttl as string',


### PR DESCRIPTION
Uses `onError = app.log.debug`, if available.

Closes #58