### PR TITLE
fix: cache types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ dist
 .clinic
 
 .vscode
+docker-compose.yml

--- a/examples/invalidation.js
+++ b/examples/invalidation.js
@@ -55,7 +55,7 @@ app.register(mercurius, {
 app.register(cache, {
   ttl: 10,
   storage: {
-    type: 'memory',
+    type: 'redis',
     options: { client: app.redis, invalidation: true }
   },
   onHit (type, fieldName) {

--- a/test/federation.test.js
+++ b/test/federation.test.js
@@ -1,0 +1,98 @@
+'use strict'
+
+const { test } = require('tap')
+const fastify = require('fastify')
+const mercurius = require('mercurius')
+const cache = require('..')
+
+const { request } = require('./helper')
+
+test('cache __resolveReference on federated service', async ({ equal, same, teardown }) => {
+  const app = fastify()
+  teardown(app.close.bind(app))
+
+  const schema = `
+  type User @key(fields: "id") {
+    id: ID!
+    name: String
+  }
+
+  type Dog {
+    name: String!
+  }
+
+  type Query {
+    getDog: Dog
+  }  
+  `
+
+  const resolvers = {
+    User: {
+      __resolveReference: async (source, args, context, info) => {
+        return { id: source.id, name: `user #${source.id}` }
+      }
+    },
+    Dog: {
+      __resolveReference: async (source, args, context, info) => {
+        return { name: 'Rocky' }
+      },
+      name: async (source, args, context, info) => {
+        return 'Rocky'
+      }
+    },
+    Query: {
+      getDog: async (source, args, context, info) => {
+        return { name: 'Lillo' }
+      }
+    }
+  }
+
+  app.register(mercurius, {
+    schema,
+    resolvers,
+    federationMetadata: true
+  })
+
+  let hits = 0
+  let misses = 0
+
+  app.register(cache, {
+    ttl: 4242,
+    onHit (type, name) { hits++ },
+    onMiss (type, name) { misses++ },
+    // it should use the cache for User.__resolveReference but not for Dog
+    policy: {
+      User: { __resolveReference: true },
+      Dog: { name: true }
+    }
+  })
+
+  let query = `query ($representations: [_Any!]!) {
+    _entities(representations: $representations) {
+      ... on User { id, name }
+    }
+  }`
+
+  const variables = {
+    representations: [
+      {
+        __typename: 'User',
+        id: 123
+      }
+    ]
+  }
+
+  same(await request({ app, query, variables }),
+    { data: { _entities: [{ id: '123', name: 'user #123' }] } })
+
+  same(await request({ app, query, variables }),
+    { data: { _entities: [{ id: '123', name: 'user #123' }] } })
+
+  query = '{ getDog { name } }'
+
+  same(await request({ app, query }),
+    { data: { getDog: { name: 'Rocky' } } })
+
+  equal(misses, 2)
+  equal(hits, 1)
+})

--- a/test/gateway.test.js
+++ b/test/gateway.test.js
@@ -4,6 +4,7 @@ const { test } = require('tap')
 const Fastify = require('fastify')
 const mercurius = require('mercurius')
 const mercuriusCache = require('..')
+
 async function createTestService (t, schema, resolvers = {}) {
   const service = Fastify({ logger: { level: 'error' } })
   service.register(mercurius, {
@@ -164,11 +165,9 @@ test('gateway - should cache it all', async (t) => {
         topPosts: true
       },
       Post: {
-        __resolveReference: true,
         category: true
       },
       Category: {
-        __resolveReference: true,
         topPosts: true
       }
     }
@@ -291,11 +290,9 @@ test('gateway - should let different fields in the query ignore the cache', asyn
         topPosts: true
       },
       Post: {
-        __resolveReference: true,
         category: true
       },
       Category: {
-        __resolveReference: true,
         topPosts: true
       }
     }

--- a/test/helper.js
+++ b/test/helper.js
@@ -3,11 +3,11 @@
 const { equal } = require('assert')
 
 module.exports = {
-  request: async function ({ app, query }) {
+  request: async function ({ app, query, variables }) {
     const res = await app.inject({
       method: 'POST',
       url: '/graphql',
-      body: { query }
+      body: { query, variables }
     })
     equal(res.statusCode, 200)
     return res.json()


### PR DESCRIPTION
solves https://github.com/mercurius-js/cache/issues/81, https://github.com/mercurius-js/cache/issues/71, https://github.com/mercurius-js/cache/issues/74

note: we may consider to drop `all` options, in gateway and federated service it caches implicitly too much
or we should implement it like `all: ['queries','resolvers' ... ]` or so