### PR TITLE
Prevent maxTTL being set to NaN

### DIFF
--- a/lib/validation.js
+++ b/lib/validation.js
@@ -81,7 +81,7 @@ function validateOpts (app, opts = {}) {
       const policyType = policy[type]
       for (const name of Object.keys(policyType)) {
         const policyField = validateNestedPolicy(policyType, name)
-        if (policyField.ttl && (typeof policyField.ttl !== 'number' || policyField.ttl < 0)) {
+        if (policyField.ttl && (typeof policyField.ttl !== 'number' || policyField.ttl < 0 || isNaN(policy.ttl))) {
           throw new Error(`policy '${type}.${name}' ttl must be a number greater than 0`)
         }
         if (policyField.storage) {
@@ -109,9 +109,7 @@ function validateOpts (app, opts = {}) {
         if (policyField.references && typeof policyField.references !== 'function') {
           throw new Error(`policy '${type}.${name}' references must be a function`)
         }
-        if (policyField.ttl && typeof policyField.ttl === 'number' && policyField.ttl > 0) {
-          maxTTL = Math.max(maxTTL, policyField.ttl)
-        }
+        maxTTL = Math.max(maxTTL, policyField.ttl)
       }
     }
   }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -11,7 +11,7 @@ function validateOpts (app, opts = {}) {
     throw new Error('policy and all options are exclusive')
   }
 
-  if (ttl && (typeof ttl !== 'number' || ttl < 0)) {
+  if (typeof ttl !== 'undefined' && (typeof ttl !== 'number' || ttl < 0 || isNaN(ttl))) {
     throw new Error('ttl must be a number greater than 0')
   }
 
@@ -81,7 +81,7 @@ function validateOpts (app, opts = {}) {
       const policyType = policy[type]
       for (const name of Object.keys(policyType)) {
         const policyField = validateNestedPolicy(policyType, name)
-        if (policyField.ttl && (typeof policyField.ttl !== 'number' || policyField.ttl < 0 || isNaN(policy.ttl))) {
+        if (typeof policyField.ttl !== 'undefined' && (typeof policyField.ttl !== 'number' || policyField.ttl < 0 || isNaN(policyField.ttl))) {
           throw new Error(`policy '${type}.${name}' ttl must be a number greater than 0`)
         }
         if (policyField.storage) {

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -109,7 +109,7 @@ function validateOpts (app, opts = {}) {
         if (policyField.references && typeof policyField.references !== 'function') {
           throw new Error(`policy '${type}.${name}' references must be a function`)
         }
-        if (!isNaN(policyField.ttl)) {
+        if (policyField.ttl && typeof policyField.ttl === 'number' && policyField.ttl > 0) {
           maxTTL = Math.max(maxTTL, policyField.ttl)
         }
       }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -109,7 +109,9 @@ function validateOpts (app, opts = {}) {
         if (policyField.references && typeof policyField.references !== 'function') {
           throw new Error(`policy '${type}.${name}' references must be a function`)
         }
-        maxTTL = Math.max(maxTTL, policyField.ttl)
+        if (policyField.ttl) {
+          maxTTL = Math.max(maxTTL, policyField.ttl)
+        }
       }
     }
   }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -109,7 +109,9 @@ function validateOpts (app, opts = {}) {
         if (policyField.references && typeof policyField.references !== 'function') {
           throw new Error(`policy '${type}.${name}' references must be a function`)
         }
-        maxTTL = Math.max(maxTTL, policyField.ttl)
+        if (!isNaN(policyField.ttl)) {
+          maxTTL = Math.max(maxTTL, policyField.ttl)
+        }
       }
     }
   }

--- a/test/lib-validation.test.js
+++ b/test/lib-validation.test.js
@@ -82,7 +82,8 @@ test('should get default storage.options.invalidation.referencesTTL as max of po
         a: { ttl: 2, storage: { type: 'redis', options: { client: {} } } },
         b: { ttl: 3, storage: { type: 'redis', options: { client: {} } } },
         c: { ttl: 4, storage: { type: 'redis', options: { client: {} } } },
-        d: { ttl: 5, storage: { type: 'redis', options: { client: {} } } }
+        d: { ttl: 5, storage: { type: 'redis', options: { client: {} } } },
+        e: { storage: { type: 'redis', options: { client: {} } } }
       }
     }
   }

--- a/test/lib-validation.test.js
+++ b/test/lib-validation.test.js
@@ -82,7 +82,8 @@ test('should get default storage.options.invalidation.referencesTTL as max of po
         a: { ttl: 2, storage: { type: 'redis', options: { client: {} } } },
         b: { ttl: 3, storage: { type: 'redis', options: { client: {} } } },
         c: { ttl: 4, storage: { type: 'redis', options: { client: {} } } },
-        d: { ttl: 5, storage: { type: 'redis', options: { client: {} } } }
+        d: { ttl: 5, storage: { type: 'redis', options: { client: {} } } },
+        e: { }
       }
     }
   }

--- a/test/lib-validation.test.js
+++ b/test/lib-validation.test.js
@@ -82,8 +82,7 @@ test('should get default storage.options.invalidation.referencesTTL as max of po
         a: { ttl: 2, storage: { type: 'redis', options: { client: {} } } },
         b: { ttl: 3, storage: { type: 'redis', options: { client: {} } } },
         c: { ttl: 4, storage: { type: 'redis', options: { client: {} } } },
-        d: { ttl: 5, storage: { type: 'redis', options: { client: {} } } },
-        e: { }
+        d: { ttl: 5, storage: { type: 'redis', options: { client: {} } } }
       }
     }
   }
@@ -167,6 +166,11 @@ const cases = [
     expect: /ttl must be a number greater than 0/
   },
   {
+    title: 'should get error using ttl NaN',
+    options: { ttl: NaN },
+    expect: /ttl must be a number greater than 0/
+  },
+  {
     title: 'should get error using onDedupe as string',
     options: { onDedupe: 'not a function' },
     expect: /onDedupe must be a function/
@@ -231,6 +235,11 @@ const cases = [
   {
     title: 'should get error using policy.ttl negative',
     options: { policy: { Query: { add: { ttl: -1 } } } },
+    expect: /ttl must be a number greater than 0/
+  },
+  {
+    title: 'should get error using policy.ttl NaN',
+    options: { policy: { Query: { add: { ttl: NaN } } } },
     expect: /ttl must be a number greater than 0/
   },
   {


### PR DESCRIPTION
Add a check when iterating policyFields to prevent maxTTL being set to NaN which prevents referencesTTL being set.
referencesTTL not being set causes the cache to behave in very unpredictable ways.

I've also added validation for ttl and policy.ttl to throw an error if either `isNaN`

```
maxTTL = Math.max(maxTTL, undefined)
maxTTL = Math.max(maxTTL, NaN)
```