### PR TITLE
fix: resolver twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ called when an error occurred on the caching operation.
 Example  
 
 ```js
-  onSkip (type, fieldName, error) {
+  onError (type, fieldName, error) {
     console.error(`error on ${type} ${fieldName}`, error)
   }
 ```

--- a/index.js
+++ b/index.js
@@ -253,11 +253,3 @@ async function getResultIfSkipDefined ({ self, arg, ctx, info, skip, policy, nam
   }
   return [result, resolved]
 }
-
-// async function getResultFromCache ({ self, arg, ctx, info, cache, name, originalFieldResolver }) {
-//   // try {
-//     return await cache[name]({ self, arg, ctx, info })
-//   // } catch (error) {
-//   //   return await originalFieldResolver(self, arg, ctx, info)
-//   // }
-// }

--- a/index.js
+++ b/index.js
@@ -198,7 +198,11 @@ function makeCachedResolver (prefix, fieldName, cache, originalFieldResolver, po
 
     // use cache to get the result
     if (!resolved) {
-      result = await getResultFromCache({ self, arg, ctx, info, cache, name, originalFieldResolver })
+      try {
+        result = await cache[name]({ self, arg, ctx, info })
+      } catch (err) {
+        // onError is already been called by cache events binding
+      }
     }
 
     if (invalidate) {
@@ -250,10 +254,10 @@ async function getResultIfSkipDefined ({ self, arg, ctx, info, skip, policy, nam
   return [result, resolved]
 }
 
-async function getResultFromCache ({ self, arg, ctx, info, cache, name, originalFieldResolver }) {
-  try {
-    return await cache[name]({ self, arg, ctx, info })
-  } catch (error) {
-    return await originalFieldResolver(self, arg, ctx, info)
-  }
-}
+// async function getResultFromCache ({ self, arg, ctx, info, cache, name, originalFieldResolver }) {
+//   // try {
+//     return await cache[name]({ self, arg, ctx, info })
+//   // } catch (error) {
+//   //   return await originalFieldResolver(self, arg, ctx, info)
+//   // }
+// }

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "fastify": "^4.5.3",
     "graphql": "^16.6.0",
     "ioredis": "^5.2.3",
-    "mercurius": "^10.0.0",
+    "mercurius": "^11.0.0",
     "snazzy": "^9.0.0",
     "split2": "^4.1.0",
     "standard": "^17.0.0",
     "tap": "^16.3.0",
-    "tsd": "^0.21.0",
+    "tsd": "^0.23.0",
     "typescript": "^4.8.2",
     "wait-on": "^6.0.1",
     "ws": "^8.8.1"
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "async-cache-dedupe": "^1.4.0",
-    "fastify-plugin": "^3.0.1"
+    "fastify-plugin": "^4.2.1"
   },
   "precommit": "test"
 }

--- a/package.json
+++ b/package.json
@@ -28,25 +28,25 @@
     "@fastify/pre-commit": "^2.0.2",
     "@sinonjs/fake-timers": "^9.1.2",
     "autocannon": "^7.9.0",
-    "concurrently": "^7.2.1",
-    "fastify": "^4.0.0",
+    "concurrently": "^7.4.0",
+    "fastify": "^4.5.3",
+    "graphql": "^16.6.0",
+    "ioredis": "^5.2.3",
     "mercurius": "^10.0.0",
-    "graphql": "^16.5.0",
-    "ioredis": "^5.0.6",
     "snazzy": "^9.0.0",
     "split2": "^4.1.0",
     "standard": "^17.0.0",
-    "tap": "^16.2.0",
+    "tap": "^16.3.0",
     "tsd": "^0.21.0",
-    "typescript": "^4.7.3",
+    "typescript": "^4.8.2",
     "wait-on": "^6.0.1",
-    "ws": "^8.8.0"
+    "ws": "^8.8.1"
   },
   "tsd": {
     "directory": "./test/types"
   },
   "dependencies": {
-    "async-cache-dedupe": "^1.2.2",
+    "async-cache-dedupe": "^1.4.0",
     "fastify-plugin": "^3.0.1"
   },
   "precommit": "test"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "directory": "./test/types"
   },
   "dependencies": {
-    "async-cache-dedupe": "^1.4.0",
+    "async-cache-dedupe": "^1.4.1",
     "fastify-plugin": "^4.2.1"
   },
   "precommit": "test"

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -100,7 +100,7 @@ test('cache a resolver', async ({ equal, same, pass, plan, teardown }) => {
 })
 
 test('No TTL, do not use cache', async ({ equal, same, pass, plan, teardown }) => {
-  plan(10)
+  plan(7)
 
   const app = fastify()
   teardown(app.close.bind(app))
@@ -128,11 +128,13 @@ test('No TTL, do not use cache', async ({ equal, same, pass, plan, teardown }) =
   })
 
   let misses = 0
+  let hits = 0
 
   app.register(cache, {
+    onHit (type, name) {
+      hits++
+    },
     onMiss (type, name) {
-      equal(type, 'Query', 'on miss')
-      equal(name, 'add')
       misses++
     },
     policy: {
@@ -147,7 +149,8 @@ test('No TTL, do not use cache', async ({ equal, same, pass, plan, teardown }) =
     query()
   ])
 
-  equal(misses, 2)
+  equal(misses, 0)
+  equal(hits, 0)
 
   async function query () {
     const query = '{ add(x: 2, y: 2) }'

--- a/test/policy-options.test.js
+++ b/test/policy-options.test.js
@@ -118,10 +118,10 @@ test('cache different policies with different options / storage', async ({ equal
   await request({ app, query: '{ sub(x: 3, y: 1) }' })
 
   equal(hits.add, 0, 'never hits the cache')
-  equal(misses.add, 3)
+  equal(misses.add, 0, 'never use the cache')
 
   equal(hits.sub, 0, 'never hits the cache')
-  equal(misses.sub, 6)
+  equal(misses.sub, 0, 'never use the cache')
 })
 
 test('cache different policies with different options / skip', async ({ equal, teardown }) => {


### PR DESCRIPTION
fixes https://github.com/mercurius-js/cache/issues/110

needs https://github.com/mcollina/async-cache-dedupe/pull/34

also update deps

note: following fix in `async-cache-dedupe` https://github.com/mcollina/async-cache-dedupe/releases/tag/v1.4.0 `onMiss` is not been called on default settings, so imo this should be a major release