### PR TITLE
feat: Support stale while revalidate cache strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ Example
   ttl: 10
 ```
 
+- **stale**
+
+the time after the ttl to serve state data while the cache values are re-validated. Has no effect if `ttl` is not configured.
+
+Example  
+
+```js
+  stale: 5
+```
+
 - **all**
 
 use the cache in all resolvers; default is false. Use either `policy` or `all` but not both.  
@@ -135,7 +145,7 @@ See [https://github.com/mercurius-js/mercurius-cache-example](https://github.com
 - **policy**
 
 specify queries to cache; default is empty.  
-Set it to `true` to cache using main `ttl`.
+Set it to `true` to cache using main `ttl` and `stale` if configured.
 Example  
 
 ```js
@@ -159,6 +169,25 @@ Example
         ttl: 5 // Query "welcome" will be cached for 5 seconds
       },
       bye: true // Query "bye" will be cached for 10 seconds
+    }
+  }
+```
+
+- **policy~stale**
+
+use a specific `ttl` for the policy, instead of the main one.  
+Example  
+
+```js
+  ttl: 10,
+  stale: 10,
+  policy: {
+    Query: {
+      welcome: {
+        ttl: 5 // Query "welcome" will be cached for 5 seconds
+        stale: 5 // Query "welcome" will availale for 5 seconds after the ttl has expired
+      },
+      bye: true // Query "bye" will be cached for 10 seconds and available for 10 seconds after the ttl is expired
     }
   }
 ```

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Example
 
 - **stale**
 
-the time after the ttl to serve state data while the cache values are re-validated. Has no effect if `ttl` is not configured.
+the time after the ttl to serve stale data while the cache values are re-validated. Has no effect if `ttl` is not configured.
 
 Example  
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const { validateOpts } = require('./lib/validation')
 const createReport = require('./lib/report')
 
 module.exports = fp(async function (app, opts) {
-  const { all, policy, ttl, skip, storage, onDedupe, onHit, onMiss, onSkip, onError, logInterval, logReport } = validateOpts(app, opts)
+  const { all, policy, ttl, stale, skip, storage, onDedupe, onHit, onMiss, onSkip, onError, logInterval, logReport } = validateOpts(app, opts)
 
   let cache = null
   let report = null
@@ -46,7 +46,7 @@ module.exports = fp(async function (app, opts) {
 
   function buildCache () {
     // Default the first two parameters of onError(prefix, fieldName, err)
-    cache = createCache({ ttl, storage, onError: onError.bind(null, 'Internal Error', 'async-cache-dedupe') })
+    cache = createCache({ ttl, stale, storage, onError: onError.bind(null, 'Internal Error', 'async-cache-dedupe') })
     report = createReport({ app, all, policy, logInterval, logReport })
   }
 }, {
@@ -127,9 +127,10 @@ function makeCachedResolver (prefix, fieldName, cache, originalFieldResolver, po
 
   report.wrap({ name, onDedupe, onHit, onMiss, onSkip })
 
-  let ttl, storage, references, invalidate
+  let ttl, stale, storage, references, invalidate
   if (policy) {
     ttl = policy.ttl
+    stale = policy.stale
     storage = policy.storage
     references = policy.references
     invalidate = policy.invalidate
@@ -141,6 +142,7 @@ function makeCachedResolver (prefix, fieldName, cache, originalFieldResolver, po
     onMiss: report[name].onMiss,
     onError,
     ttl,
+    stale,
     storage,
     references,
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,7 +1,7 @@
 'use strict'
 
 function validateOpts (app, opts = {}) {
-  let { all, policy, ttl, skip, storage, onDedupe, onHit, onMiss, onSkip, onError, logInterval, logReport } = opts
+  let { all, policy, ttl, stale, skip, storage, onDedupe, onHit, onMiss, onSkip, onError, logInterval, logReport } = opts
 
   if (all && typeof all !== 'boolean') {
     throw new Error('all must be a boolean')
@@ -13,6 +13,10 @@ function validateOpts (app, opts = {}) {
 
   if (typeof ttl !== 'undefined' && (typeof ttl !== 'number' || ttl < 0 || isNaN(ttl))) {
     throw new Error('ttl must be a number greater than 0')
+  }
+
+  if (typeof stale !== 'undefined' && (typeof stale !== 'number' || stale < 0 || isNaN(stale))) {
+    throw new Error('stale must be a number greater than 0')
   }
 
   if (skip && typeof skip !== 'function') {
@@ -129,7 +133,7 @@ function validateOpts (app, opts = {}) {
     storage = { type: 'memory' }
   }
 
-  return { all, policy, ttl, skip, storage, onDedupe, onHit, onMiss, onSkip, onError, logInterval, logReport }
+  return { all, policy, ttl, stale, skip, storage, onDedupe, onHit, onMiss, onSkip, onError, logInterval, logReport }
 }
 
 // TODO need to validate also nested

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test, mock, before, teardown } = require('tap')
+const { test, mock, before, teardown, afterEach } = require('tap')
 const fastify = require('fastify')
 const mercurius = require('mercurius')
 const FakeTimers = require('@sinonjs/fake-timers')
@@ -18,6 +18,10 @@ before(() => {
     shouldAdvanceTime: true,
     advanceTimeDelta: 0
   })
+})
+
+afterEach(() => {
+  clock.runAll()
 })
 
 teardown(() => {

--- a/test/lib-validation.test.js
+++ b/test/lib-validation.test.js
@@ -172,6 +172,21 @@ const cases = [
     expect: /ttl must be a number greater than 0/
   },
   {
+    title: 'should get error using stale as string',
+    options: { stale: '10' },
+    expect: /stale must be a number greater than 0/
+  },
+  {
+    title: 'should get error using stale negative',
+    options: { stale: -1 },
+    expect: /stale must be a number greater than 0/
+  },
+  {
+    title: 'should get error using stale NaN',
+    options: { stale: NaN },
+    expect: /stale must be a number greater than 0/
+  },
+  {
     title: 'should get error using onDedupe as string',
     options: { onDedupe: 'not a function' },
     expect: /onDedupe must be a function/


### PR DESCRIPTION
Adds support for the state-while-revalidate strategy that is now supported in async-cache-dedupe via https://github.com/mcollina/async-cache-dedupe/pull/45

closes #121 

**Note:** this also includes a change to how `FakeTimers` are setup for tests. The way the memory store manages the timers for the ttl means that tests needs to share the installed fake timer and run all timers at the end of the test (`afterEach`) for clean up.

cc @simone-sanfratello 