### PR TITLE
feat: Support dynamic ttl function option

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Storage options are:
   - for `redis`
     - **client**: a redis client instance, mandatory. Should be an `ioredis` client or compatible.
     - **invalidation**: enable invalidation, see [documentation](#invalidation). Default is disabled.
-    - **invalidation.referencesTTL**: references TTL in seconds. Default is the max `ttl` between the main one and policies.
+    - **invalidation.referencesTTL**: references TTL in seconds. Default is the max static `ttl` between the main one and policies. If all ttls specified are functions then `referencesTTL` will need to be specified explictly.
     - **log**: logger instance `pino` compatible, default is the `app.log` instance.
 
     Example

--- a/README.md
+++ b/README.md
@@ -71,11 +71,16 @@ app.listen(3000)
 
 - **ttl**
 
-the time to live in seconds; default is `0`, which means that the cache is disabled.
-Example  
+a number or a function that returns a number of the maximum time a cache entry can live in seconds; default is `0`, which means that the cache is disabled. The ttl function reveives the result of the original function as the first argument.
+
+Example(s) 
 
 ```js
   ttl: 10
+```
+
+...js
+  ttl: (result) => !!result.importantProp ? 10 : 0
 ```
 
 - **stale**
@@ -168,14 +173,15 @@ Example
       welcome: {
         ttl: 5 // Query "welcome" will be cached for 5 seconds
       },
-      bye: true // Query "bye" will be cached for 10 seconds
+      bye: true, // Query "bye" will be cached for 10 seconds
+      hello: (result) => result.shouldCache ? 15 : 0 // function that determines the ttl for how long the item should be cached
     }
   }
 ```
 
 - **policy~stale**
 
-use a specific `ttl` for the policy, instead of the main one.  
+use a specific `stale` value for the policy, instead of the main one.  
 Example  
 
 ```js

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ import { MercuriusPlugin } from "mercurius";
 export type TtlFunction = (...args: any[]) => number;
 export interface PolicyFieldOptions {
   ttl?: number | TtlFunction;
+  stale?: number;
   storage?: MercuriusCacheStorageMemory | MercuriusCacheStorageRedis;
   extendKey?: Function;
   skip?: Function;
@@ -47,6 +48,7 @@ export interface MercuriusCacheOptions {
   all?: boolean;
   policy?: MercuriusCachePolicy;
   ttl?: number | TtlFunction;
+  stale?: number;
   skip?: Function;
   storage?: MercuriusCacheStorageMemory | MercuriusCacheStorageRedis;
   onDedupe?: Function;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,9 @@
 import { FastifyPluginAsync } from "fastify";
 import { MercuriusPlugin } from "mercurius";
+
+export type TtlFunction = (...args: any[]) => number;
 export interface PolicyFieldOptions {
-  ttl?: number;
+  ttl?: number | TtlFunction;
   storage?: MercuriusCacheStorageMemory | MercuriusCacheStorageRedis;
   extendKey?: Function;
   skip?: Function;
@@ -44,7 +46,7 @@ export interface MercuriusCacheStorageRedis extends MercuriusCacheStorage {
 export interface MercuriusCacheOptions {
   all?: boolean;
   policy?: MercuriusCachePolicy;
-  ttl?: number;
+  ttl?: number | TtlFunction;
   skip?: Function;
   storage?: MercuriusCacheStorageMemory | MercuriusCacheStorageRedis;
   onDedupe?: Function;

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -11,8 +11,8 @@ function validateOpts (app, opts = {}) {
     throw new Error('policy and all options are exclusive')
   }
 
-  if (typeof ttl !== 'undefined' && (typeof ttl !== 'number' || ttl < 0 || isNaN(ttl))) {
-    throw new Error('ttl must be a number greater than 0')
+  if (typeof ttl !== 'undefined' && typeof ttl !== 'function' && (typeof ttl !== 'number' || ttl < 0 || isNaN(ttl))) {
+    throw new Error('ttl must be a function or a number greater than 0')
   }
 
   if (typeof stale !== 'undefined' && (typeof stale !== 'number' || stale < 0 || isNaN(stale))) {
@@ -85,8 +85,12 @@ function validateOpts (app, opts = {}) {
       const policyType = policy[type]
       for (const name of Object.keys(policyType)) {
         const policyField = validateNestedPolicy(policyType, name)
-        if (typeof policyField.ttl !== 'undefined' && (typeof policyField.ttl !== 'number' || policyField.ttl < 0 || isNaN(policyField.ttl))) {
-          throw new Error(`policy '${type}.${name}' ttl must be a number greater than 0`)
+
+        if (typeof policyField.ttl !== 'undefined' && typeof policyField.ttl !== 'function' && (typeof policyField.ttl !== 'number' || policyField.ttl < 0 || isNaN(policyField.ttl))) {
+          throw new Error(`policy '${type}.${name}' ttl must be a function or a number greater than 0`)
+        }
+        if (typeof policyField.stale !== 'undefined' && (typeof policyField.stale !== 'number' || policyField.stale < 0 || isNaN(policyField.stale))) {
+          throw new Error(`policy '${type}.${name}' stale must be a number greater than 0`)
         }
         if (policyField.storage) {
           const validation = validateStorage(app, policyField.storage)

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -74,8 +74,10 @@ function validateOpts (app, opts = {}) {
     onError = noop
   }
 
-  if (!ttl) { ttl = 0 }
-  let maxTTL = ttl
+  if (!ttl) {
+    ttl = 0
+  }
+  let maxTTL = typeof ttl === 'number' ? ttl : 0
   if (policy) {
     if (typeof policy !== 'object' && !all) {
       throw new Error('policy must be an object')
@@ -117,7 +119,7 @@ function validateOpts (app, opts = {}) {
         if (policyField.references && typeof policyField.references !== 'function') {
           throw new Error(`policy '${type}.${name}' references must be a function`)
         }
-        if (policyField.ttl) {
+        if (typeof policyField.ttl === 'number') {
           maxTTL = Math.max(maxTTL, policyField.ttl)
         }
       }
@@ -125,7 +127,7 @@ function validateOpts (app, opts = {}) {
   }
 
   if (storage) {
-    if (ttl < 1 && maxTTL < 1) {
+    if (!ttl && maxTTL < 1) {
       throw new Error('storage is set but no ttl or policy ttl is set')
     }
     const validation = validateStorage(app, storage, maxTTL)
@@ -165,13 +167,17 @@ function validateStorage (app, storage, maxTTL) {
     _storage.options = {}
   }
 
-  if (_storage.type === 'redis' && maxTTL && _storage.options.invalidation &&
-    (typeof _storage.options.invalidation === 'boolean' || (_storage.options.invalidation && !_storage.options.invalidation.referencesTTL))) {
-    _storage.options = {
-      ..._storage.options,
-      invalidation: {
-        ..._storage.options.invalidation,
-        referencesTTL: maxTTL + 1
+  if (_storage.type === 'redis' && _storage.options.invalidation) {
+    if (typeof _storage.options.invalidation === 'boolean' || !_storage.options.invalidation.referencesTTL) {
+      if (typeof maxTTL !== 'number' || isNaN(maxTTL) || maxTTL < 1) {
+        throw new Error('at least one ttl must be a positive integer greater than 1 to use for storage.invalidation.referencesTTL, please specify the option explictly.')
+      }
+      _storage.options = {
+        ..._storage.options,
+        invalidation: {
+          ..._storage.options.invalidation,
+          referencesTTL: maxTTL + 1
+        }
       }
     }
   }

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -88,10 +88,17 @@ function validateOpts (app, opts = {}) {
       for (const name of Object.keys(policyType)) {
         const policyField = validateNestedPolicy(policyType, name)
 
-        if (typeof policyField.ttl !== 'undefined' && typeof policyField.ttl !== 'function' && (typeof policyField.ttl !== 'number' || policyField.ttl < 0 || isNaN(policyField.ttl))) {
+        if (
+          typeof policyField.ttl !== 'undefined' &&
+          typeof policyField.ttl !== 'function' &&
+          (typeof policyField.ttl !== 'number' || policyField.ttl < 0 || isNaN(policyField.ttl))
+        ) {
           throw new Error(`policy '${type}.${name}' ttl must be a function or a number greater than 0`)
         }
-        if (typeof policyField.stale !== 'undefined' && (typeof policyField.stale !== 'number' || policyField.stale < 0 || isNaN(policyField.stale))) {
+        if (
+          typeof policyField.stale !== 'undefined' &&
+          (typeof policyField.stale !== 'number' || policyField.stale < 0 || isNaN(policyField.stale))
+        ) {
           throw new Error(`policy '${type}.${name}' stale must be a number greater than 0`)
         }
         if (policyField.storage) {

--- a/test/lib-validation.test.js
+++ b/test/lib-validation.test.js
@@ -130,11 +130,17 @@ test('should not throw error when "__options" is used with valid parameters', as
         a: {
           __options: {
             ttl: 2,
+            stale: 10,
             storage: { type: 'redis', options: { client: {} } },
             extendKey: () => {},
             skip: () => {},
             invalidate: () => {},
             references: () => {}
+          }
+        },
+        b: {
+          __options: {
+            ttl: () => 10
           }
         }
       }
@@ -159,17 +165,17 @@ const cases = [
   {
     title: 'should get error using ttl as string',
     options: { ttl: '10' },
-    expect: /ttl must be a number greater than 0/
+    expect: /ttl must be a function or a number greater than 0/
   },
   {
     title: 'should get error using ttl negative',
     options: { ttl: -1 },
-    expect: /ttl must be a number greater than 0/
+    expect: /ttl must be a function or a number greater than 0/
   },
   {
     title: 'should get error using ttl NaN',
     options: { ttl: NaN },
-    expect: /ttl must be a number greater than 0/
+    expect: /ttl must be a function or a number greater than 0/
   },
   {
     title: 'should get error using stale as string',
@@ -246,17 +252,32 @@ const cases = [
   {
     title: 'should get error using policy.ttl as string',
     options: { policy: { Query: { add: { ttl: '10' } } } },
-    expect: /ttl must be a number greater than 0/
+    expect: /ttl must be a function or a number greater than 0/
   },
   {
     title: 'should get error using policy.ttl negative',
     options: { policy: { Query: { add: { ttl: -1 } } } },
-    expect: /ttl must be a number greater than 0/
+    expect: /ttl must be a function or a number greater than 0/
   },
   {
     title: 'should get error using policy.ttl NaN',
     options: { policy: { Query: { add: { ttl: NaN } } } },
-    expect: /ttl must be a number greater than 0/
+    expect: /ttl must be a function or a number greater than 0/
+  },
+  {
+    title: 'should get error using policy.stale as string',
+    options: { policy: { Query: { add: { stale: '10' } } } },
+    expect: /stale must be a number greater than 0/
+  },
+  {
+    title: 'should get error using policy.stale negative',
+    options: { policy: { Query: { add: { stale: -1 } } } },
+    expect: /stale must be a number greater than 0/
+  },
+  {
+    title: 'should get error using policy.stale NaN',
+    options: { policy: { Query: { add: { stale: NaN } } } },
+    expect: /stale must be a number greater than 0/
   },
   {
     title: 'should get error using policy.extendKey not a function',

--- a/test/lib-validation.test.js
+++ b/test/lib-validation.test.js
@@ -96,7 +96,7 @@ test('should get default storage.options.invalidation.referencesTTL as max of po
 test('should get default storage.options.invalidation.referencesTTL as max of policies and main ttl / invalidation as empty object', async (t) => {
   const options = {
     ttl: 1,
-    storage: { type: 'redis', options: { client: {}, invalidation: {} } },
+    storage: { type: 'redis', options: { client: {}, invalidation: true } },
     policy: {
       Query: {
         a: { ttl: 2, storage: { type: 'redis', options: { client: {} } } },
@@ -109,6 +109,80 @@ test('should get default storage.options.invalidation.referencesTTL as max of po
   const app = { log: 'the-logger' }
   const { storage } = validateOpts(app, options)
 
+  t.equal(storage.options.invalidation.referencesTTL, 6)
+})
+
+test('should not default storage.options.invalidation.referencesTTL when all ttls are functions / invalidation as boolean true', async (t) => {
+  const options = {
+    ttl: () => 1,
+    storage: { type: 'redis', options: { client: {}, invalidation: true } },
+    policy: {
+      Query: {
+        a: { ttl: () => 2, storage: { type: 'redis', options: { client: {} } } },
+        b: { ttl: () => 3, storage: { type: 'redis', options: { client: {} } } },
+        c: { ttl: () => 4, storage: { type: 'redis', options: { client: {} } } },
+        d: { ttl: () => 5, storage: { type: 'redis', options: { client: {} } } }
+      }
+    }
+  }
+  const app = { log: 'the-logger' }
+  t.throws(() => {
+    validateOpts(app, options)
+  }, '')
+})
+
+test('should not default storage.options.invalidation.referencesTTL when all ttls are functions / invalidation as empty object', async (t) => {
+  const options = {
+    ttl: () => 1,
+    storage: { type: 'redis', options: { client: {}, invalidation: {} } },
+    policy: {
+      Query: {
+        a: { ttl: () => 2, storage: { type: 'redis', options: { client: {} } } },
+        b: { ttl: () => 3, storage: { type: 'redis', options: { client: {} } } },
+        c: { ttl: () => 4, storage: { type: 'redis', options: { client: {} } } },
+        d: { ttl: () => 5, storage: { type: 'redis', options: { client: {} } } }
+      }
+    }
+  }
+  const app = { log: 'the-logger' }
+  t.throws(() => {
+    validateOpts(app, options)
+  }, '')
+})
+
+test('should default storage.options.invalidation.referencesTTL to max ttl when a mix of static and dynamic ttls are configured / invalidation as boolean true', async (t) => {
+  const options = {
+    ttl: () => 1,
+    storage: { type: 'redis', options: { client: {}, invalidation: true } },
+    policy: {
+      Query: {
+        a: { ttl: () => 2, storage: { type: 'redis', options: { client: {} } } },
+        b: { ttl: 3, storage: { type: 'redis', options: { client: {} } } },
+        c: { ttl: () => 4, storage: { type: 'redis', options: { client: {} } } },
+        d: { ttl: 1, storage: { type: 'redis', options: { client: {} } } }
+      }
+    }
+  }
+  const app = { log: 'the-logger' }
+  const { storage } = validateOpts(app, options)
+  t.equal(storage.options.invalidation.referencesTTL, 4)
+})
+
+test('should use explicitly defined referencesTTL', async (t) => {
+  const options = {
+    ttl: () => 1,
+    storage: { type: 'redis', options: { client: {}, invalidation: { referencesTTL: 6 } } },
+    policy: {
+      Query: {
+        a: { ttl: () => 2, storage: { type: 'redis', options: { client: {} } } },
+        b: { ttl: 3, storage: { type: 'redis', options: { client: {} } } },
+        c: { ttl: () => 4, storage: { type: 'redis', options: { client: {} } } },
+        d: { ttl: 1, storage: { type: 'redis', options: { client: {} } } }
+      }
+    }
+  }
+  const app = { log: 'the-logger' }
+  const { storage } = validateOpts(app, options)
   t.equal(storage.options.invalidation.referencesTTL, 6)
 })
 

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -20,7 +20,8 @@ app.register(mercuriusCache, emptyCacheOptions);
 expectAssignable<MercuriusCacheContext | undefined>(app.graphql.cache)
 
 const queryFieldPolicy = {
-  ttl: 1,
+  ttl: (result: { shouldCache: boolean }) => result.shouldCache ? 10 : 0,
+  stale: 10,
   storage: { type: MercuriusCacheStorageType.MEMORY, options: { size: 1 } },
 };
 
@@ -68,7 +69,7 @@ expectNotAssignable<MercuriusCacheStorageRedis>(cacheMemoryStorage);
 const allValidCacheOptions = {
   all: false,
   policy: queryPolicy,
-  ttl: 1000,
+  ttl: () => 1000,
   skip: () => {
     console.log("skip called!");
   },


### PR DESCRIPTION
Adds support for defining a dynamic ttl via a function in the cache options. This leverages the existing support for a dynamic ttl in https://github.com/mcollina/async-cache-dedupe.

Previously for redis when "invalidation" is enabled the `referencesTTL` is defaulted to the maximum `ttl` value from all the configuration values, this isn't possible with a dynamic ttl, as the function cannot be resolved until the function has been executed - for this scenario we use the maximum determinable ttl (if there is a least one static ttl defined) and where there are no static ttl option through an error stating that the `referencesTTL` option needs to be explicitly defined.

This includes some changes that were missing from #121 - namely policy level validation (and tests) plus the typings for `stale` - I can split this out into a separate pull request is required.

closes #137 

cc @simone-sanfratello 