### PR TITLE
docs: minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Example(s)
   ttl: 10
 ```
 
-...js
+```js
   ttl: (result) => !!result.importantProp ? 10 : 0
 ```
 
@@ -213,7 +213,7 @@ Example
   policy: {
     Query: {
       countries: {
-        ttl: 1440, // Query "countries" will be cached for 1 day
+        ttl: 86400, // Query "countries" will be cached for 1 day
         storage: { type: 'memory' }
       }
     }


### PR DESCRIPTION
The `ttl` example actually confused me. I believe it is in seconds, so it should be 86400, 1440 would be 24 minutes.