### PR TITLE
chore: update deps and tests - drop node 16 and redis 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
-        redis-tag: [5, 6, 7]
+        node-version: [18.x, 20.x]
+        redis-tag: [6, 7]
     services:
       redis:
         image: redis:${{ matrix.redis-tag }}

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "mercurius-cache",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Cache the results of your GraphQL resolvers, for Mercurius",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {
     "test": "standard | snazzy && tap test/*test.js && tsd",
-    "redis": "docker run -p 6379:6379 --rm redis:5",
+    "redis": "docker run -p 6379:6379 --rm redis:7",
     "lint:fix": "standard --fix"
   },
   "repository": {
@@ -27,30 +27,30 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.0.2",
     "@sinonjs/fake-timers": "^11.1.0",
-    "autocannon": "^7.10.0",
-    "concurrently": "^8.0.1",
-    "fastify": "^4.11.0",
-    "graphql": "^16.6.0",
+    "autocannon": "^7.12.0",
+    "concurrently": "^8.2.1",
+    "fastify": "^4.23.2",
+    "graphql": "^16.8.1",
     "graphql-type-json": "^0.3.2",
-    "ioredis": "^5.2.5",
-    "mercurius": "^13.0.0",
+    "ioredis": "^5.3.2",
+    "mercurius": "^13.1.0",
     "snazzy": "^9.0.0",
-    "split2": "^4.1.0",
-    "standard": "^17.0.0",
+    "split2": "^4.2.0",
+    "standard": "^17.1.0",
     "tap": "^16.3.4",
     "tsd": "^0.29.0",
-    "typescript": "^5.0.2",
+    "typescript": "^5.2.2",
     "wait-on": "^7.0.1",
-    "ws": "^8.12.0",
+    "ws": "^8.14.2",
     "@mercuriusjs/federation": "^2.0.0",
-    "@mercuriusjs/gateway": "^1.0.0"
+    "@mercuriusjs/gateway": "^2.0.0"
   },
   "tsd": {
     "directory": "./test/types"
   },
   "dependencies": {
     "async-cache-dedupe": "^2.0.0",
-    "fastify-plugin": "^4.5.0"
+    "fastify-plugin": "^4.5.1"
   },
   "precommit": "test"
 }


### PR DESCRIPTION
as titled

Drop node 16 and redis 5
