### PR TITLE
make report not assume query is named "Query"

### DIFF
--- a/lib/report.js
+++ b/lib/report.js
@@ -14,7 +14,7 @@ class Report {
     this.log = opts.app.log
     const schema = opts.app.graphql.schema
     const fields = opts.all
-      ? Object.keys(schema.getQueryType().getFields()).map(field => `Query.${field}`)
+      ? Object.keys(schema.getQueryType().getFields()).map(field => `${schema.getQueryType()}.${field}`)
       : this.getPolicies(opts.policy)
 
     for (const field of fields) {
@@ -91,7 +91,7 @@ class Report {
 }
 
 function createReport ({ app, all, policy, logInterval, logReport }) {
-  if (!logInterval || !((policy && policy.Query) || all)) {
+  if (!logInterval || !((policy && policy[app.graphql.schema.getQueryType()]) || all)) {
     const disabled = {
       clear: noop,
       refresh: noop,


### PR DESCRIPTION
The cache report was assuming the name of the query is literally "Query". This fix changes that to use the name of the query from the schema.