### PR TITLE
test: migrated refresh.test.js from tap to node:test

### DIFF
--- a/test/refresh.test.js
+++ b/test/refresh.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const FakeTimers = require('@sinonjs/fake-timers')
 const { promisify } = require('util')
 const Fastify = require('fastify')
@@ -13,13 +13,13 @@ const { buildSchema } = require('graphql')
 const immediate = promisify(setImmediate)
 
 test('polling interval with a new schema should trigger refresh of schema policy build', async (t) => {
-  t.plan(6)
+  t.plan(8)
 
   const clock = FakeTimers.install({
     shouldAdvanceTime: true,
     advanceTimeDelta: 40
   })
-  t.teardown(() => clock.uninstall())
+  t.after(() => clock.uninstall())
 
   const user = {
     id: 'u1',
@@ -30,7 +30,7 @@ test('polling interval with a new schema should trigger refresh of schema policy
   const resolvers = {
     Query: {
       me: (root, args, context, info) => {
-        t.pass('resolver called')
+        t.assert.ok('resolver called')
         return user
       }
     }
@@ -38,7 +38,7 @@ test('polling interval with a new schema should trigger refresh of schema policy
 
   const userService = Fastify()
   const gateway = Fastify({ logger: { level: 'error' } })
-  t.teardown(async () => {
+  t.after(async () => {
     await gateway.close()
     await userService.close()
   })
@@ -98,7 +98,7 @@ test('polling interval with a new schema should trigger refresh of schema policy
       body: { query }
     })
 
-    t.same(res.json(), {
+    t.assert.deepStrictEqual(res.json(), {
       data: {
         me: {
           id: 'u1',
@@ -111,7 +111,7 @@ test('polling interval with a new schema should trigger refresh of schema policy
   await getMe()
   await getMe()
 
-  t.comment('userService.graphql.replaceSchema')
+  t.assert.ok('userService.graphql.replaceSchema')
 
   userService.graphql.replaceSchema(
     buildFederationSchema(`
@@ -152,7 +152,7 @@ test('polling interval with a new schema should trigger refresh of schema policy
       body: { query }
     })
 
-    t.same(res.json(), {
+    t.assert.deepStrictEqual(res.json(), {
       data: {
         me: {
           id: 'u1',
@@ -163,13 +163,13 @@ test('polling interval with a new schema should trigger refresh of schema policy
     })
   }
 
-  t.comment('refreshed service calls')
+  t.assert.ok('refreshed service calls')
   await getMeWithLastName()
   await getMeWithLastName()
 })
 
 test('adds a mercuriusCache.refresh() method', async (t) => {
-  t.plan(6)
+  t.plan(8)
 
   const user = {
     id: 'u1',
@@ -180,14 +180,14 @@ test('adds a mercuriusCache.refresh() method', async (t) => {
   const resolvers = {
     Query: {
       me: (root, args, context, info) => {
-        t.pass('resolver called')
+        t.assert.ok('resolver called')
         return user
       }
     }
   }
 
   const userService = Fastify()
-  t.teardown(async () => {
+  t.after(async () => {
     await userService.close()
   })
 
@@ -230,7 +230,7 @@ test('adds a mercuriusCache.refresh() method', async (t) => {
       body: { query }
     })
 
-    t.same(res.json(), {
+    t.assert.deepStrictEqual(res.json(), {
       data: {
         me: {
           id: 'u1',
@@ -243,7 +243,7 @@ test('adds a mercuriusCache.refresh() method', async (t) => {
   await getMe()
   await getMe()
 
-  t.comment('userService.graphql.cache.refresh()')
+  t.assert.ok('userService.graphql.cache.refresh()')
 
   userService.graphql.replaceSchema(buildSchema(`
       type Query {
@@ -284,7 +284,7 @@ test('adds a mercuriusCache.refresh() method', async (t) => {
       body: { query }
     })
 
-    t.same(res.json(), {
+    t.assert.deepStrictEqual(res.json(), {
       data: {
         me: {
           id: 'u1',
@@ -295,7 +295,7 @@ test('adds a mercuriusCache.refresh() method', async (t) => {
     })
   }
 
-  t.comment('refreshed service calls')
+  t.assert.ok('refreshed service calls')
   await getMeWithLastName()
   await getMeWithLastName()
 })


### PR DESCRIPTION
Proposal:

- migrated `refresh.test.js` from `tap` to `node:test` 🔥