### PR TITLE
test: migrated base.test.js from tap to node:test

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
   "homepage": "https://github.com/mercurius-js/cache#readme",
   "devDependencies": {
     "@fastify/pre-commit": "^2.0.2",
+    "@mercuriusjs/federation": "^5.0.0",
+    "@mercuriusjs/gateway": "^5.0.0",
     "@sinonjs/fake-timers": "^11.1.0",
     "autocannon": "^7.12.0",
     "concurrently": "^9.0.0",
@@ -34,6 +36,7 @@
     "graphql-type-json": "^0.3.2",
     "ioredis": "^5.3.2",
     "mercurius": "^16.0.0",
+    "proxyquire": "^2.1.3",
     "snazzy": "^9.0.0",
     "split2": "^4.2.0",
     "standard": "^17.1.0",
@@ -41,9 +44,7 @@
     "tsd": "^0.31.0",
     "typescript": "^5.2.2",
     "wait-on": "^8.0.0",
-    "ws": "^8.14.2",
-    "@mercuriusjs/federation": "^5.0.0",
-    "@mercuriusjs/gateway": "^5.0.0"
+    "ws": "^8.14.2"
   },
   "tsd": {
     "directory": "./test/types"


### PR DESCRIPTION
Proposals:

- migrated `base.test.js` from `tap` to `node:test` 🔥
- added the `proxyquire` package to mock `async-cache-dedupe` when importing the cache module, because currently `node:test` does not provide a default method to do this. 